### PR TITLE
Revert and decommission

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Search Engine Usage Study
+# Search Engine Usage Study [DECOMMISSIONED]
 A study to assess how individuals interact with their search engines.
 
 ## Requirements

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "author": "Kartikeya Kandula",
   "manifest_version": 2,
   "name": "Search Engine Usage and Result Quality Study",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "homepage_url": "https://github.com/mozilla-rally/search-engine-usage-study",
   "applications": {
     "gecko": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "search_engine_usage_study",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "scripts": {
     "build": "npm run build:glean && rollup -c && rollup -c rollup.config.content-scripts.js && npm run package",
     "build:glean": "npm run build:glean:metrics && npm run build:glean:docs",

--- a/src/background.ts
+++ b/src/background.ts
@@ -128,3 +128,10 @@ rally.initialize(
     // went wrong.
     console.error(err);
 });
+
+browser.runtime.onInstalled.addListener(() => {
+    console.log(
+        "Search engine study has been decommissioned. Uninstalling self..."
+    );
+    browser.management.uninstallSelf();
+});

--- a/src/content-scripts/common.ts
+++ b/src/content-scripts/common.ts
@@ -1076,7 +1076,12 @@ const selfPreferencedResultMetadataReplacement: {
     cite: "https://www.google.com",
     citeSpan: " › travel › flights",
     getResults: function (): Element[] {
-      return getXPathElements("//*[@id='rso']/*[descendant::g-more-link[descendant::span[text()='Search on Google Flights']]]");
+
+      if (document.querySelector("#kp-wp-tab-AIRFARES")) {
+        return [];
+      } else {
+        return getXPathElements("//*[@id='rso']/*[descendant::g-more-link[descendant::span[text()='Search on Google Flights']]]");
+      }
     },
     getReplacementData: function (element: Element): ReplacementDataVariableSubset {
       return {


### PR DESCRIPTION
Revert previous changes for relaunching the study (those have moved to here: https://github.com/mozilla-extensions/search-engine-usage-study-relaunch)

Implement self-uninstall for relaunch